### PR TITLE
Fix progress bars and finish automation

### DIFF
--- a/app/src/main/java/com/example/idlecraft/MainActivity.kt
+++ b/app/src/main/java/com/example/idlecraft/MainActivity.kt
@@ -12,20 +12,13 @@ package com.example.idlecraft
 
 import android.content.SharedPreferences
 import android.os.Bundle
-import android.util.Log
-import android.view.View
-import android.widget.Button
 import android.widget.ProgressBar
 import com.google.android.material.bottomnavigation.BottomNavigationView
 import androidx.appcompat.app.AppCompatActivity
-import androidx.fragment.app.Fragment
 import androidx.navigation.findNavController
 import androidx.navigation.ui.AppBarConfiguration
-import androidx.navigation.ui.setupActionBarWithNavController
 import androidx.navigation.ui.setupWithNavController
 import com.example.idlecraft.mechanics.Inventory
-import com.example.idlecraft.mechanics.Item
-import kotlinx.android.synthetic.main.fragment_gather.view.*
 
 class MainActivity : AppCompatActivity() {
     // Member Fields

--- a/app/src/main/java/com/example/idlecraft/MainActivity.kt
+++ b/app/src/main/java/com/example/idlecraft/MainActivity.kt
@@ -30,8 +30,7 @@ import kotlinx.android.synthetic.main.fragment_gather.view.*
 class MainActivity : AppCompatActivity() {
     // Member Fields
     var inventory = Inventory()
-    var updateThreadInventory: Boolean = false
-    var updateThreadCrafting: Boolean = false
+    var currentFragment: String = ""
     val gatheringSpeed: Long = 2500
     val autosaveSpeed: Long = 10000
 
@@ -138,14 +137,13 @@ class MainActivity : AppCompatActivity() {
                 try { Thread.sleep(gatheringSpeed / 100) }
                 catch (e: InterruptedException) { e.printStackTrace() }
                 progress += 1
-                if (progress > 100) progress = 0
+                if (progress > 100) progress = 1
 
                 inventory.items.forEach {
                     if (it.rate > 1) {
                         // update progress bar to reflect progress if it exists in the view
                         runOnUiThread {
-                            // if the item is at max count, leave progress at 100
-                            setProgress(if (it.count < it.max) progress else 100, it.name, "gath")
+                            setProgress(if (it.count >= it.max) 0 else progress, it.name, "gath")
                         }
 
                         // update inventory at 100%

--- a/app/src/main/java/com/example/idlecraft/MainActivity.kt
+++ b/app/src/main/java/com/example/idlecraft/MainActivity.kt
@@ -160,27 +160,29 @@ class MainActivity : AppCompatActivity() {
     }
 
     //==============================================================================================
-    // startGatherProgress: Starts a thread to handle the gathering of an item and the animation
-    //                      of the progress bar.
+    // startGatherProgress: Starts a thread to handle the gathering/crafting of an item and the
+    //                      animation of the progress bar.
     //==============================================================================================
-    fun startGatherProgress(itemName: String) {
+    fun startProgress(itemName: String, fragmentName: String, amount: Int) {
         val item = inventory.getItemByName(itemName)
 
         Thread(Runnable {
-            for (progress in 1..100) {
-                runOnUiThread {
-                    setProgress(progress, itemName, "gath")
+            for (i in 1..amount) {
+                for (progress in 1..100) {
+                    runOnUiThread {
+                        setProgress(progress, itemName, fragmentName)
+                    }
+                    try { Thread.sleep(gatheringSpeed / 100) }
+                    catch (e: InterruptedException) { e.printStackTrace() }
                 }
-                try { Thread.sleep(gatheringSpeed / 100) }
-                catch (e: InterruptedException) { e.printStackTrace() }
-            }
-            if (item.count + item.rate <= item.max) {
-                item.increaseCount(item.rate)
-            } else {
-                item.count = item.max
+                if (item.count + item.rate <= item.max) {
+                    item.increaseCount(item.rate)
+                } else {
+                    item.count = item.max
+                }
             }
             runOnUiThread {
-                setProgress(0, itemName, "gath")
+                setProgress(0, itemName, fragmentName)
             }
         }).start()
     }

--- a/app/src/main/java/com/example/idlecraft/ui/CraftFragment.kt
+++ b/app/src/main/java/com/example/idlecraft/ui/CraftFragment.kt
@@ -11,6 +11,7 @@
 package com.example.idlecraft.ui
 
 import android.os.Bundle
+import android.util.Log
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
@@ -135,35 +136,34 @@ class CraftFragment : Fragment() {
         }
 
         // Update Thread: activate Crafting
-        act!!.updateThreadCrafting = true
-        act!!.updateThreadInventory = false
-        var craftThread = act!!.updateThreadCrafting
+        act!!.currentFragment = "craft"
 
         // Thread constantly updates all crafting TextViews to reflect the player's inventory
         // while this fragment is open. This is needed because inventory values are constantly
         // changing and updating.
         Thread(Runnable {
-            while (craftThread) {
-                activity?.runOnUiThread {
-                    craftItems.forEach {
-                        val item = inv.getItemByName(it)
+            while (act!!.currentFragment == "craft") {
+                craftItems.forEach {
+                    val item = inv.getItemByName(it)
 
-                        // Declare strings to reference a set of UI elements for an item
-                        val countStr    = "text_craft_${it}_count"
-                        val craftReqStr = "text_craft_${it}_req"
+                    // Declare strings to reference a set of UI elements for an item
+                    val countStr    = "text_craft_${it}_count"
+                    val craftReqStr = "text_craft_${it}_req"
 
-                        // Use the UI strings to reference each UI element then update them
-                        val itemCount = view.findViewById<TextView>(resources.getIdentifier(countStr, "id", pkg))
-                        val craftReq1 = view.findViewById<TextView>(resources.getIdentifier(craftReqStr + "1", "id", pkg))
-                        val craftReq2 = view.findViewById<TextView>(resources.getIdentifier(craftReqStr + "2", "id", pkg))
-                        val craftReq3 = view.findViewById<TextView>(resources.getIdentifier(craftReqStr + "3", "id", pkg))
+                    // Use the UI strings to reference each UI element then update them
+                    val itemCount = view.findViewById<TextView>(resources.getIdentifier(countStr, "id", pkg))
+                    val craftReq1 = view.findViewById<TextView>(resources.getIdentifier(craftReqStr + "1", "id", pkg))
+                    val craftReq2 = view.findViewById<TextView>(resources.getIdentifier(craftReqStr + "2", "id", pkg))
+                    val craftReq3 = view.findViewById<TextView>(resources.getIdentifier(craftReqStr + "3", "id", pkg))
+
+                    // Update the quantity and rate TextViews
+                    act!!.runOnUiThread {
                         updateItemText(itemCount, item)
                         updateReqText(craftReq1, craftReq2, craftReq3, item)
                     }
                 }
                 // Sleep and constantly check to see if thread needs to stay alive
                 Thread.sleep(25)
-                craftThread = act!!.updateThreadCrafting
             }
         }).start()
         return view

--- a/app/src/main/java/com/example/idlecraft/ui/CraftFragment.kt
+++ b/app/src/main/java/com/example/idlecraft/ui/CraftFragment.kt
@@ -98,22 +98,7 @@ class CraftFragment : Fragment() {
             if (progressBar.progress != 0 || item.count >= item.max || !inv.isCraftable(item, amountToCraft))
                 return@setOnClickListener
 
-            Thread(Runnable { // Thread animates progress bar
-                var progress = 0
-                while (progress < progressBar.max) {
-                    progress += 1
-                    progressBar.progress = progress
-                    try { Thread.sleep(21) }
-                    catch (e: InterruptedException) { e.printStackTrace() }
-                }
-                progressBar.progress = 0     // Reset progress bar
-                inv.craftItem(item, amountToCraft)
-                // runOnUiThread allows the thread to update UI objects
-                activity?.runOnUiThread {
-                    updateItemText(itemCount, item)
-                    updateReqText(craftReq1, craftReq2, craftReq3, item)
-                }
-            }).start()
+            act!!.startProgress(itemName, "craft", amountToCraft)
         }
 
         // The plus button allows a player to craft more items at a time.

--- a/app/src/main/java/com/example/idlecraft/ui/CraftFragment.kt
+++ b/app/src/main/java/com/example/idlecraft/ui/CraftFragment.kt
@@ -11,7 +11,6 @@
 package com.example.idlecraft.ui
 
 import android.os.Bundle
-import android.util.Log
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup

--- a/app/src/main/java/com/example/idlecraft/ui/GatherFragment.kt
+++ b/app/src/main/java/com/example/idlecraft/ui/GatherFragment.kt
@@ -77,25 +77,7 @@ class GatherFragment : Fragment() {
             if (progressBar.progress != 0 || item.count >= item.max)
                 return@setOnClickListener
 
-            Thread(Runnable { // Thread animates the progress bar
-                var progress = 0
-                // Gathering speed must be divided by progressBar.max(100) because the thread
-                // sleeps 100 times per while loop iteration.
-                val progressBarSpeed = act!!.gatheringSpeed / progressBar.max
-                while (progress < progressBar.max) {
-                    progress += 1
-                    progressBar.progress = progress
-                    try { Thread.sleep(progressBarSpeed) }
-                    catch (e: InterruptedException) { e.printStackTrace() }
-                }
-                progressBar.progress = 0  // Reset progress bar
-                item.count += item.rate   // Increment number of sticks
-                if (item.count > item.max) item.count = item.max
-                // runOnUiThread allows the thread to update UI objects
-                activity?.runOnUiThread {
-                    updateQuantityText(itemQuantity, item)
-                }
-            }).start()
+            act!!.startGatherProgress(itemName)
         }
     }
 

--- a/app/src/main/java/com/example/idlecraft/ui/GatherFragment.kt
+++ b/app/src/main/java/com/example/idlecraft/ui/GatherFragment.kt
@@ -77,7 +77,7 @@ class GatherFragment : Fragment() {
             if (progressBar.progress != 0 || item.count >= item.max)
                 return@setOnClickListener
 
-            act!!.startGatherProgress(itemName)
+            act!!.startProgress(itemName, "gath", 1)
         }
     }
 

--- a/app/src/main/java/com/example/idlecraft/ui/InventoryFragment.kt
+++ b/app/src/main/java/com/example/idlecraft/ui/InventoryFragment.kt
@@ -15,7 +15,6 @@ import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import android.widget.ImageButton
-import android.widget.ProgressBar
 import android.widget.TextView
 import androidx.fragment.app.Fragment
 import com.example.idlecraft.R
@@ -23,7 +22,6 @@ import com.example.idlecraft.MainActivity
 import com.example.idlecraft.mechanics.Inventory
 import com.example.idlecraft.mechanics.Item
 import kotlinx.android.synthetic.main.fragment_inventory.view.*
-import java.security.KeyStore
 
 class InventoryFragment : Fragment() {
     // Private Member Fields

--- a/app/src/main/java/com/example/idlecraft/ui/InventoryFragment.kt
+++ b/app/src/main/java/com/example/idlecraft/ui/InventoryFragment.kt
@@ -155,15 +155,13 @@ class InventoryFragment : Fragment() {
         }
 
         // Update Thread: activate Inventory
-        act!!.updateThreadCrafting = false
-        act!!.updateThreadInventory = true
-        var invThread = act!!.updateThreadInventory
+        act!!.currentFragment = "inventory"
 
         // Thread constantly updates all inventory TextViews to reflect the player's inventory
         // while this fragment is open. This is needed because inventory values are constantly
         // changing and updating.
         Thread(Runnable {
-            while(invThread) {
+            while(act!!.currentFragment == "inventory") {
                 invItems.forEach {
                     val item = inv.getItemByName(it)
                     updateMoneyText(textMoney, inv.money)
@@ -184,7 +182,6 @@ class InventoryFragment : Fragment() {
                 }
                 // Sleep and constantly check to see if thread needs to stay alive
                 Thread.sleep(25)
-                invThread = act!!.updateThreadInventory
             }
         }).start()
         return view

--- a/app/src/main/java/com/example/idlecraft/ui/ShopFragment.kt
+++ b/app/src/main/java/com/example/idlecraft/ui/ShopFragment.kt
@@ -166,9 +166,7 @@ class ShopFragment : Fragment() {
             setupShopItemListeners(view, it)
         }
 
-        // Update Thread: activate Shop
-        act!!.updateThreadCrafting = false
-        act!!.updateThreadInventory = false
+        act!!.currentFragment = "shop"
 
         return view
     }


### PR DESCRIPTION
Progress bar animation and gather automation now run on threads in MainActivity and only update UI components if they can find them in the current top-level view. Also, when crafting more than 1 item at a time, the progress bar will now animate that many times and craft the items one at a time instead of animating once and crafting them all at once. I also made a thread to update the gather fragment TextViews for automation.